### PR TITLE
fix Selenium version to latest 4.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
 	<description>Selenium example project</description>
 	<properties>
 		<java.version>17</java.version>
+		<selenium.version>4.9.0</selenium.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
this overrides Selenium version 4.5.3 forced by spring-boot-starter-test plugin

https://lmgtfy.app/?q=spring-boot-starter-test+override+version

P.S. I hate the fact that spring boot test plugin (both in Maven and Gradle) silently overrides versions. And it's almost impossible to understand who did this shit. :(